### PR TITLE
Pass through and spread props for browse and search

### DIFF
--- a/src/lib/hooks/use-algolia-browse-all.js
+++ b/src/lib/hooks/use-algolia-browse-all.js
@@ -4,13 +4,19 @@ const useAlgoliaBrowseAll = ({
   indexName,
   query = '',
   hitsPerPage = 1000,
-  filters
+  filters,
+  ...props
 }) => {
   const index = useAlgoliaIndex({ indexName });
 
   return {
     browse: index
-      ? () => index.browseAll(query, { hitsPerPage, facetFilters: filters })
+      ? () =>
+          index.browseAll(query, {
+            hitsPerPage,
+            facetFilters: filters,
+            ...props
+          })
       : () => Promise.resolve([])
   };
 };

--- a/src/lib/hooks/use-algolia-lazy-search.js
+++ b/src/lib/hooks/use-algolia-lazy-search.js
@@ -43,7 +43,8 @@ const useAlgoliaLazySearch = ({
   page = 0,
   hitsPerPage = 10,
   delay = 800,
-  key = 0
+  key = 0,
+  ...props
 }) => {
   const handlerRef = useRef();
   const [{ loading, searchResults, error }, dispatch] = useReducer(
@@ -70,7 +71,8 @@ const useAlgoliaLazySearch = ({
           query,
           filters,
           page: page < 0 ? 0 : page,
-          hitsPerPage
+          hitsPerPage,
+          ...props
         });
 
         if (cancelled) {

--- a/src/lib/hooks/use-algolia-search.js
+++ b/src/lib/hooks/use-algolia-search.js
@@ -48,7 +48,8 @@ const useAlgoliaSearch = ({
   page = 0,
   hitsPerPage = 10,
   delay = 800,
-  key = 0
+  key = 0,
+  ...props
 }) => {
   const handlerRef = useRef();
   const [{ loading, searchResults, error }, dispatch] = useReducer(
@@ -74,7 +75,8 @@ const useAlgoliaSearch = ({
           query,
           filters,
           page: page < 0 ? 0 : page,
-          hitsPerPage
+          hitsPerPage,
+          ...props
         });
 
         if (cancelled) {


### PR DESCRIPTION
Catches the `...rest` params and passes them through to the underlying algoliasearch methods for:
- `use-algolia-browse-all`
- `use-algolia-search`
- `use-algolia-lazy-search`